### PR TITLE
Add detection rule for long PowerShell Start-Sleep

### DIFF
--- a/indicators/ps_exposed_pr_author.yaml
+++ b/indicators/ps_exposed_pr_author.yaml
@@ -1,0 +1,12 @@
+name: Uncommon Start-Sleep time COPY
+description: Detects unusually long PowerShell sleep intervals specified via Start-Sleep with large numeric values, a common sandbox- and analysis-evasion technique used to delay execution until security tooling times out.
+regex: start-sleep\b(?:\s+-s(?:econds)?\s+(?:6\d{2,}|[7-9]\d{2,}|\d{4,})|\s+-m(?:inutes)?\s+(?:1\d+|[2-9]\d*)|\s+(?:6\d{2,}|[7-9]\d{2,}|\d{4,}))
+basescore: 10
+tactic: [TA0005]
+technique: [T1497.003]
+reference:
+  - https://securitylabs.datadoghq.com/articles/mut-9332-malicious-solidity-vscode-extensions/
+  - https://www.esentire.com/blog/esentire-threat-intelligence-malware-analysis-purple-fox
+  - https://attack.mitre.org/techniques/T1497/003/
+  - https://github.com/SigmaHQ/sigma/blob/master/rules/windows/powershell/powershell_script/posh_ps_long_sleep.yml
+  - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1497.003/T1497.003.md


### PR DESCRIPTION
This rule detects unusually long PowerShell sleep intervals, which can be used to evade security tools.

## 🎯 Type of Change

- [ ] 🆕 New indicator
- [ ] 🔧 Existing indicator improvement
- [ ] 🐛 Bug fix
- [ ] 📚 Documentation update

## 💬 Description

<!-- Briefly describe what this PR does -->


## 📋 Checklist

- [ ] Followed contribution guidelines
- [ ] File naming is correct (`ps_indicator_*.yaml`)
- [ ] MITRE ATT&CK mapping is correct
- [ ] Included relevant references
- [ ] Score is appropriate (1-10)
- [ ] Description is clear and concise
---

**🔒 By submitting this PR, you agree that your contributions will be licensed under the MIT License.**
